### PR TITLE
Fix/eastregion keep info on updates

### DIFF
--- a/src/manager/InstanceManager.js
+++ b/src/manager/InstanceManager.js
@@ -105,7 +105,7 @@ InstanceManager = function(refs) {
     };
 };
 
-InstanceManager.prototype.getLayout = function(layoutConfig, applyKeys) {
+InstanceManager.prototype.getLayout = function(layoutConfig, fromFavorite) {
     var t = this,
         favorite = t.getStateFavorite(),
         layout;
@@ -115,7 +115,9 @@ InstanceManager.prototype.getLayout = function(layoutConfig, applyKeys) {
     layout = new t.api.Layout(t.refs, layoutConfig);
 
     if (layout) {
-        layout.apply(favorite, applyKeys);
+        layout = fromFavorite ? 
+            favorite.apply(layout, Object.keys(layout)) : 
+            layout.apply(favorite);
     }
 
     return layout;
@@ -332,16 +334,7 @@ InstanceManager.prototype.getReport = function(layout, isFavorite, skipState, fo
 
     // layout
     if (!layout) {
-        layout = this.getLayout(undefined, [
-            'id',
-            'name',
-            'description',
-            'created',
-            'displayDescription',
-            'lastUpdated',
-            'user',
-            'interpretations'
-        ]);
+        layout = this.getLayout(undefined, true);
 
         if (!layout) {
             return;

--- a/src/manager/InstanceManager.js
+++ b/src/manager/InstanceManager.js
@@ -334,7 +334,7 @@ InstanceManager.prototype.getReport = function(layout, isFavorite, skipState, fo
 
     // layout
     if (!layout) {
-        layout = this.getLayout(undefined, true);
+        layout = t.getLayout(undefined, true);
 
         if (!layout) {
             return;

--- a/src/manager/InstanceManager.js
+++ b/src/manager/InstanceManager.js
@@ -105,7 +105,7 @@ InstanceManager = function(refs) {
     };
 };
 
-InstanceManager.prototype.getLayout = function(layoutConfig) {
+InstanceManager.prototype.getLayout = function(layoutConfig, applyKeys) {
     var t = this,
         favorite = t.getStateFavorite(),
         layout;
@@ -115,7 +115,7 @@ InstanceManager.prototype.getLayout = function(layoutConfig) {
     layout = new t.api.Layout(t.refs, layoutConfig);
 
     if (layout) {
-        layout.apply(favorite);
+        layout.apply(favorite, applyKeys);
     }
 
     return layout;
@@ -332,7 +332,16 @@ InstanceManager.prototype.getReport = function(layout, isFavorite, skipState, fo
 
     // layout
     if (!layout) {
-        layout = t.getLayout();
+        layout = this.getLayout(undefined, [
+            'id',
+            'name',
+            'description',
+            'created',
+            'displayDescription',
+            'lastUpdated',
+            'user',
+            'interpretations'
+        ]);
 
         if (!layout) {
             return;

--- a/src/manager/InstanceManager.js
+++ b/src/manager/InstanceManager.js
@@ -115,7 +115,7 @@ InstanceManager.prototype.getLayout = function(layoutConfig, fromFavorite) {
     layout = new t.api.Layout(t.refs, layoutConfig);
 
     if (layout) {
-        layout = fromFavorite ? 
+        layout = favorite && fromFavorite ? 
             favorite.apply(layout, Object.keys(layout)) : 
             layout.apply(favorite);
     }

--- a/src/ui/EastRegion.js
+++ b/src/ui/EastRegion.js
@@ -50,7 +50,7 @@ EastRegion = function(c) {
         // Favorite loaded ->  Add favorite detail panel and update
         // Otherwise -> Display No Favorite Panel
         var detailsPanelItems;
-        if (instanceManager.isStateFavorite() && !instanceManager.isStateDirty()) {
+        if (instanceManager.isStateFavorite()) {
 
             var moreText = i18n.show_more;
             var lessText = i18n.show_less;
@@ -261,7 +261,6 @@ EastRegion = function(c) {
         itemId: 'detailsPanel',
 
         addAndUpdateFavoritePanel: function(layout) {
-
             // Remove any previous panel
             this.removeAll(true);
 
@@ -939,13 +938,11 @@ EastRegion = function(c) {
         items: [detailsPanel, interpretationsPanel],
         cls: 'eastPanel',
         setState: function(layout) {
-            if (layout.interpretations) {
-                this.getComponent('detailsPanel').addAndUpdateFavoritePanel(layout);
+            this.getComponent('detailsPanel').addAndUpdateFavoritePanel(layout);
 
-                // Favorite loaded with interpretations ->  Add interpretation panel and update
-            
-                this.getComponent('interpretationsPanel').addAndUpdateInterpretationsPanel(layout);
-            }
+            // Favorite loaded with interpretations ->  Add interpretation panel and update
+    
+            this.getComponent('interpretationsPanel').addAndUpdateInterpretationsPanel(layout);
         },
         listeners: {
             expand: function() {


### PR DESCRIPTION
Fixes #13 

It works like this: on updates, `getReport(layout, ...)` is called without `layout`. In this case, we now use the current favorite as base object and apply the current layout over. This way, the render has the changes requested on the update (new elements, options, etc) but also keeps the favorite info and interpretations. Tested all favorite actions (save/save-as/new/...), it works fine. 