### PR TITLE
Check permissions for favorite and interpretations

### DIFF
--- a/src/api/Layout.js
+++ b/src/api/Layout.js
@@ -152,6 +152,11 @@ Layout = function(refs, c, applyConfig, forceApplyConfig) {
         t.userGroupAccesses = c.userGroupAccesses;
     }
 
+    //user accesses
+    if (arrayFrom(c.userAccesses).length) {
+        t.userAccesses = c.userAccesses;
+    }
+
     if (c.el && isString(c.el)) {
         t.el = c.el;
     }
@@ -489,6 +494,7 @@ Layout.prototype.toPlugin = function(el) {
             'user',
             'publicAccess',
             'permission',
+            'userAccesses',
             'userGroupAccesses',
             'prototype',
             'url',
@@ -598,7 +604,7 @@ Layout.prototype.toPostSuper = function() {
     delete this.created;
     delete this.user;
     delete this.publicAccess;
-    delete this.permission, delete this.userGroupAccesses;
+    delete this.permission, delete this.userGroupAccesses, delete this.userAccesses;
     delete this.displayName;
 };
 

--- a/src/manager/InstanceManager.js
+++ b/src/manager/InstanceManager.js
@@ -255,9 +255,9 @@ InstanceManager.prototype.getSharingById = function(id, fn, options) {
             fn && fn(r);
         },
         error: function(res) {
-            // If allowForbidden enabled, call the callback anyway, with an empty object
-            if (res.status == 403 && options.allowForbidden) {
-                success(null);
+            // If allowForbidden enabled, call the callback anyway, without response object
+            if (res.status === 403 && options.allowForbidden) {
+                fn && fn();
             } else {
                 t.uiManager.alert(res);
                 t.uiManager.unmask();
@@ -266,7 +266,7 @@ InstanceManager.prototype.getSharingById = function(id, fn, options) {
     });
 
     request.add({
-        type: t.apiResource,
+        type: options.apiResource || t.apiResource,
         id: id
     });
 

--- a/src/ui/EastRegion.js
+++ b/src/ui/EastRegion.js
@@ -22,11 +22,22 @@ EastRegion = function(c) {
 
     var descriptionMaxNumberCharacter = 500;
 
-    var openInterpretationWindow = function(id, interpretation, success) {
+    var openInterpretationWindow = function(id, interpretation, success, options) {
+        var { renderText = true, renderSharing = true } = options || {};
+        var favorite = instanceManager.getStateFavorite();
         var favoriteId = id || instanceManager.getStateFavoriteId();
-        instanceManager.getSharingById(favoriteId, function(r) {
-            InterpretationWindow(c, r, interpretation, success).show();
-        }, {allowForbidden: true});
+        var isNewInterpretation = !interpretation || !interpretation.id;
+
+        if (renderSharing) {
+            var [apiResource, sharingObjectId] = isNewInterpretation
+                ? [null, favoriteId]
+                : ["interpretation", interpretation.id];
+            instanceManager.getSharingById(sharingObjectId, function(sharing) {
+                InterpretationWindow(c, sharing, interpretation, success, options).show();
+            }, {apiResource, allowForbidden: true});
+        } else {
+            InterpretationWindow(c, null, interpretation, success, options).show();
+        }
     };
 
     var userCanManageInterpretation = function(interpretation) {
@@ -698,11 +709,11 @@ EastRegion = function(c) {
         };
 
         // Update an interpretation update data model and update/reload panel
-        var editInterpretation = function(el) {
+        var editInterpretation = function(el, options) {
             openInterpretationWindow(null, interpretation, function() {
                 var interpretationPanel = el.up('#interpretationPanel' + interpretation.id);
                 interpretationPanel.updateInterpretationPanelItems(interpretation);
-            });
+            }, options);
         };
 
         // Delete an interpretation and return to main interpretations panel
@@ -862,7 +873,24 @@ EastRegion = function(c) {
                         listeners: {
                             'render': function(label) {
                                 label.getEl().on('click', function() {
-                                    editInterpretation(this);
+                                    editInterpretation(this, { renderText: true, renderSharing: false });
+                                }, this);
+                            }
+                        }
+                    }, {
+                        xtype: 'label',
+                        text: '·',
+                        hidden: !userCanManageInterpretation(interpretation),
+                        style: 'margin-right: 5px;'
+                    }, {
+                        xtype: 'label',
+                        html: getLink(i18n.sharing),
+                        hidden: !userCanManageInterpretation(interpretation),
+                        style: 'margin-right: 5px;',
+                        listeners: {
+                            'render': function(label) {
+                                label.getEl().on('click', function() {
+                                    editInterpretation(this, { renderText: false, renderSharing: true });
                                 }, this);
                             }
                         }

--- a/src/ui/SharingWindow.js
+++ b/src/ui/SharingWindow.js
@@ -113,7 +113,7 @@ SharingWindow = function(c, sharing, configOnly) {
                                 const currentObject = getBody().object;
                                 const accessToRemove = cmp.up('panel').getAccess();
                                 const field = cmp.up('#' + userGroupRowContainer.id) ? "userGroupAccesses" : "userAccesses"
-                                const currentAccesses = currentObject[field];
+                                const currentAccesses = currentObject[field] || [];
                                 const newAccesses = currentAccesses.filter(access => access.id !== accessToRemove.id);
 
                                 if (validateAccessField(field, currentAccesses, newAccesses)) {
@@ -265,16 +265,18 @@ SharingWindow = function(c, sharing, configOnly) {
                     };
 
                     if (record.data.isGroup) {
+                        const userGroupAccesses = currentObject.userGroupAccesses || [];
                         if (validateAccessField("userGroupAccesses",
-                                currentObject.userGroupAccesses,
-                                currentObject.userGroupAccesses.concat([newAccess]))) {
+                                userGroupAccesses,
+                                userGroupAccesses.concat([newAccess]))) {
                             userGroupRowContainer.add(SharingAccessRow(newAccess));
                         }
                     }
                     else {
+                        const userAccesses = currentObject.userAccesses || [];
                         if (validateAccessField("userAccesses",
-                                currentObject.userAccesses,
-                                currentObject.userAccesses.concat([newAccess]))) {
+                                userAccesses,
+                                userAccesses.concat([newAccess]))) {
                             userRowContainer.add(SharingAccessRow(newAccess));
                         }
                     }

--- a/src/ui/SharingWindow.js
+++ b/src/ui/SharingWindow.js
@@ -1,4 +1,5 @@
 import isArray from 'd2-utilizr/lib/isArray';
+import { validateFieldAccess, validateSharing } from '../util/permissions';
 
 export var SharingWindow;
 
@@ -27,6 +28,21 @@ SharingWindow = function(c, sharing, configOnly) {
 
         items,
         window;
+
+    var showSharingError = function() {
+        var modelName = sharing.object.modelName;
+        var errorMessage = modelName === "interpretation"
+            ? i18n.validation_error_interpretation_sharing
+            : i18n.validation_error_object_sharing;
+        uiManager.alert(errorMessage);
+    };
+
+    var favorite = instanceManager.getStateFavorite();
+
+    var validateAccessField = function(field, oldValue, newValue) {
+        var modelName = sharing.object.modelName;
+        return validateFieldAccess(modelName, favorite, showSharingError, field, oldValue, newValue);
+    };
 
     SharingAccessRow = function(obj, isPublicAccess, disallowPublicAccess) {
         var getData,
@@ -71,7 +87,14 @@ SharingWindow = function(c, sharing, configOnly) {
                 editable: false,
                 disabled: !!disallowPublicAccess,
                 value: obj.access || 'rw------',
-                store: store
+                store: store,
+                listeners: {
+                    select: function(combo) {
+                        if (isPublicAccess && !validateAccessField("publicAccess", obj.access, combo.getValue())) {
+                            combo.setValue(obj.access);
+                        }
+                    }
+                },
             });
 
             items.push(combo);
@@ -87,10 +110,18 @@ SharingWindow = function(c, sharing, configOnly) {
                     listeners: {
                         render: function(cmp) {
                             cmp.getEl().on('click', function(e) {
-                                cmp.up('panel').destroy();
+                                const currentObject = getBody().object;
+                                const accessToRemove = cmp.up('panel').getAccess();
+                                const field = cmp.up('#' + userGroupRowContainer.id) ? "userGroupAccesses" : "userAccesses"
+                                const currentAccesses = currentObject[field];
+                                const newAccesses = currentAccesses.filter(access => access.id !== accessToRemove.id);
 
-                                if (window) {
-                                    window.doLayout();
+                                if (validateAccessField(field, currentAccesses, newAccesses)) {
+                                    cmp.up('panel').destroy();
+
+                                    if (window) {
+                                        window.doLayout();
+                                    }
                                 }
                             });
                         }
@@ -224,21 +255,28 @@ SharingWindow = function(c, sharing, configOnly) {
         Object.assign({}, buttonConfig, {
             handler: function(b) {
                 const record = sharingStore.getById(sharingField.getValue());
+                const currentObject = getBody().object;
 
                 if (record && record.data) {
+                    var newAccess = {
+                        id: record.data.id,
+                        name: record.data.name,
+                        access: 'r-------'
+                    };
+
                     if (record.data.isGroup) {
-                        userGroupRowContainer.add(SharingAccessRow({
-                            id: record.data.id,
-                            name: record.data.name,
-                            access: 'r-------'
-                        }));
+                        if (validateAccessField("userGroupAccesses",
+                                currentObject.userGroupAccesses,
+                                currentObject.userGroupAccesses.concat([newAccess]))) {
+                            userGroupRowContainer.add(SharingAccessRow(newAccess));
+                        }
                     }
                     else {
-                        userRowContainer.add(SharingAccessRow({
-                            id: record.data.id,
-                            name: record.data.name,
-                            access: 'r-------'
-                        }));
+                        if (validateAccessField("userAccesses",
+                                currentObject.userAccesses,
+                                currentObject.userAccesses.concat([newAccess]))) {
+                            userRowContainer.add(SharingAccessRow(newAccess));
+                        }
                     }
                 }
 
@@ -368,6 +406,9 @@ SharingWindow = function(c, sharing, configOnly) {
                 {
                     text: i18n.save,
                     handler: function() {
+                        if (!validateSharing(sharing.object.modelName, favorite, getBody().object, showSharingError))
+                            return;
+
                         Ext.Ajax.request({
                             url: encodeURI(apiPath + '/sharing?type=' + instanceManager.apiResource + '&id=' + sharing.object.id),
                             method: 'POST',

--- a/src/util/permissions.js
+++ b/src/util/permissions.js
@@ -1,0 +1,92 @@
+/* Helpers to control access permissions of favorites and interpretations.
+ *
+ * A favorite sharing must be a superset of all its interpretations sharings.
+ * An interpretation sharing must be a subset of its parent object sharing.
+
+ Permissions checked: publicAccess, userGroupAccesses and userAccesses.
+ */
+
+const accesses = {
+    "--------": "private",
+    "r-------": "read",
+    "rw------": "read-write",
+};
+
+const permissionFields = [
+    "publicAccess",
+    "userAccesses",
+    "userGroupAccesses",
+];
+
+const toArray = (obj) => obj || [];
+
+export const checkValidationCondition = function(validator, oldValue, newValue, showError) {
+    const oldValueValidates = oldValue ? validator(oldValue) : true;
+    const newValueValidates = validator(newValue);
+
+    if (oldValueValidates && newValueValidates) {
+        return true;
+    } else if (oldValueValidates && !newValueValidates) {
+        showError && showError();
+        return false;
+    } else if (!oldValueValidates && newValueValidates) {
+        return true;
+    } else if (!oldValueValidates && !newValueValidates) {
+        showError && showError();
+        return true;
+    }
+};
+
+const isObjectAccessible = function(favoriteAccess, objectAccess) {
+    return !(accesses[favoriteAccess] === "private" && accesses[objectAccess] !== "private");
+};
+
+export const validateFieldAccess = function(modelName, favorite, showError, field, oldValue, newValue) {
+    const modelKey = modelName === "interpretation" ? modelName : "favorite";
+    const interpretations = toArray(favorite.interpretations);
+    let predicate;
+
+    switch (modelKey + "-" + field) {
+        /* Interpretations validations: check that its sharing is a subset of the favorite sharing */
+        case "interpretation-publicAccess":
+            predicate = value => isObjectAccessible(favorite[field], value);
+            break;
+        case "interpretation-userAccesses":
+        case "interpretation-userGroupAccesses":
+            const favoritePermissionIds = new Set(toArray(favorite[field]).map(p => p.id));
+            predicate = permissions => toArray(permissions)
+                .every(permission => favoritePermissionIds.has(permission.id));
+            break;
+
+        /* Favorite validations: check that all its interpretation sharings are a subset of this favorite sharing */
+        case "favorite-publicAccess":
+            predicate = value =>
+                interpretations.every(interpretation => isObjectAccessible(value, interpretation[field]));
+            break;
+        case "favorite-userAccesses":
+        case "favorite-userGroupAccesses":
+            predicate = favoritePermissions => {
+                const favoritePermissionIds = new Set(toArray(favoritePermissions).map(p => p.id));
+                return interpretations.every(interpretation =>
+                    toArray(interpretation[field]).every(interpretationPermission =>
+                        favoritePermissionIds.has(interpretationPermission.id)));
+            };
+            break;
+        default:
+            throw new Error("[validateFieldAccess] unknown field key: " + modelKey);
+    }
+
+    return checkValidationCondition(predicate, oldValue, newValue, showError);
+};
+
+export const validateSharing = function(modelName, favorite, sharing, showError) {
+    if (!favorite || !sharing) {
+        return true;
+    } else {
+        const isValid = permissionFields.every(field =>
+            validateFieldAccess(modelName, favorite, null, field, null, sharing[field]));
+        if (!isValid)
+            showError();
+        return isValid;
+    }
+};


### PR DESCRIPTION
Fixes https://github.com/EyeSeeTea/dhis2-core/issues/40

Requires https://github.com/EyeSeeTea/dhis2-visualizer/pull/7

Internal PR. Some notes:

- On interpretation create -> show textarea and sharing
- On interpretation edit -> show only textarea
- On interpretation share -> show only sharing

Validations:
- An interpretation publicAccess must be private if parent object is private.
- An interpretation user and userGroup accesses must be a subset of parent object.

- An object publicAccess must be public if any interpretation is public
- An object user and userGroup accesses must be a superset of each interpretation.

Next steps, once validated:
- Create test steps in JIRA.
- Create upstream PR.