### PR TITLE
Limit max users to show in mentions window

### DIFF
--- a/src/ui/MentionToolbar.js
+++ b/src/ui/MentionToolbar.js
@@ -18,9 +18,15 @@ MentionToolbar = function (refs) {
         zIndex: 9999,
         cls: 'mentions',
         createMentionLabelsForUser : function(users, splitText, currentMention, component){
+            const currentMentionLowerCase = currentMention.toLowerCase();
+
             return users
-                    .filter(user => (user.userCredentials.username.toLowerCase().includes(currentMention.toLowerCase()) || user.displayName.toLowerCase().includes(currentMention.toLowerCase())))
-                    .map((user) => {
+                    .filter(user => (
+                        user.userCredentials.username.toLowerCase().includes(currentMentionLowerCase) ||
+                        user.displayName.toLowerCase().includes(currentMentionLowerCase)
+                    ))
+                    .slice(0, 50)
+                    .map(user => {
                         return {
                             xtype: 'label',
                             html:  user.displayName + " (" + user.userCredentials.username + ")",


### PR DESCRIPTION
Limit users to render in mentions window to 50 (similar to maps-app, which uses default dhis2 pagination with per_page=50) to avoid long render times.