### PR TITLE
Use object.access to determine permissions

### DIFF
--- a/src/api/Layout.js
+++ b/src/api/Layout.js
@@ -142,11 +142,6 @@ Layout = function(refs, c, applyConfig, forceApplyConfig) {
         t.publicAccess = c.publicAccess;
     }
 
-    //permission
-    if (isString(c.permission)) {
-        t.permission = c.permission;
-    }
-
     //user group accesses
     if (arrayFrom(c.userGroupAccesses).length) {
         t.userGroupAccesses = c.userGroupAccesses;
@@ -488,7 +483,6 @@ Layout.prototype.toPlugin = function(el) {
             'created',
             'user',
             'publicAccess',
-            'permission',
             'userGroupAccesses',
             'prototype',
             'url',
@@ -598,7 +592,7 @@ Layout.prototype.toPostSuper = function() {
     delete this.created;
     delete this.user;
     delete this.publicAccess;
-    delete this.permission, delete this.userGroupAccesses;
+    delete this.userGroupAccesses;
     delete this.displayName;
 };
 

--- a/src/manager/InstanceManager.js
+++ b/src/manager/InstanceManager.js
@@ -165,23 +165,8 @@ InstanceManager.prototype.getById = function(id, fn, doMask, doUnmask) {
             }
         },
         success: function(r) {
-            $.ajax({
-                url: appManager.getApiPath() + '/' + t.apiEndpoint + '/' + id,
-                type: 'PATCH',
-                data: JSON.stringify({}),
-                // avoid jQuery choke on empty 200 Success response
-                dataType: 'text',
-                headers: appManager.defaultRequestHeaders,
-                success: function(sharing) {
-                    var layout = new Layout(refs, r, {permission: "write"});
-                    fn(layout, true);
-                },
-                error: function(xhr) {
-                    var permission = xhr.status === 404 ? "none" : "read";
-                    var layout = new Layout(refs, r, {permission: permission});
-                    fn(layout, true);
-                }
-            });
+            var layout = new Layout(refs, r);
+            fn(layout, true);
         },
         error: function(r) {
             if (arrayContains([403], parseInt(r.httpStatusCode))) {

--- a/src/ui/EastRegion.js
+++ b/src/ui/EastRegion.js
@@ -178,7 +178,7 @@ EastRegion = function(c) {
                 }
 
                 // Change Link
-                if (layout && layout.permission === "write") {
+                if (layout && layout.getAccess().update) {
                     descriptionItems.push({
                         xtype: 'label',
                         html: getLink(editText, false, true),
@@ -241,7 +241,7 @@ EastRegion = function(c) {
             }
 
             // Favorite Details Panel content when favorite loaded
-            var userCanEditSharing = layout && layout.permission === 'write';
+            var userCanEditSharing = layout && layout.getAccess().update;
 
             detailsPanelItems = [{
                 xtype: 'panel',
@@ -397,7 +397,7 @@ EastRegion = function(c) {
                 bodyStyle: 'border-style:none',
                 layout: 'column',
                 itemId: 'commentPanel-' + (comment ? comment.id : "new"),
-                hidden: !visible || (!layout || layout.permission === "none"),
+                hidden: !visible || !interpretation.access.update,
                 style: 'margin-top: 1px;',
                 cls: 'comment greyBackground',
                 items: [{
@@ -536,11 +536,13 @@ EastRegion = function(c) {
                         }, {
                             xtype: 'label',
                             style: 'color: #666',
+                            hidden: !interpretation.access.update,
                             text: DateManager.getTimeDifference(comment.lastUpdated) + ' ' + i18n.ago
                         }, {
                             xtype: 'label',
                             html: getLink(i18n.reply),
                             style: 'margin-right: 5px; margin-left: 5px',
+                            hidden: !interpretation.access.update,
                             listeners: {
                                 'render': (function(comment_) {
                                     return function(label) {
@@ -823,7 +825,7 @@ EastRegion = function(c) {
                     xtype: 'panel',
                     bodyStyle: 'border-style:none',
                     style: 'margin-bottom: 5px;',
-                    hidden: !layout || layout.permission === "none",
+                    hidden: !interpretation.access.read,
 
                     items: [{
                         xtype: 'label',
@@ -836,10 +838,12 @@ EastRegion = function(c) {
                         }
                     }, {
                         xtype: 'label',
+                        hidden: !interpretation.access.update,
                         text: '·',
                         style: 'margin-right: 5px;'
                     }, {
                         xtype: 'label',
+                        hidden: !interpretation.access.update,
                         html: getLink(i18n.reply),
                         style: 'margin-right: 5px;',
                         listeners: {
@@ -984,7 +988,7 @@ EastRegion = function(c) {
             xtype: 'panel',
             bodyStyle: 'border-style:none',
             style: 'padding:6px; border-width:0 0 1px 0; border-style:solid;',
-            hidden: displayingInterpretation || (!layout || layout.permission === "none"),
+            hidden: displayingInterpretation || (!layout || !layout.getAccess().read),
             itemId: 'shareInterpretation',
             items: [{
                 xtype: 'label',


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes https://github.com/EyeSeeTea/dhis2-core/issues/55

### :memo: Implementation

- Removed `layout.permission` attribute, use directly `layout.getAccess()` (when checking on favorite) and `interpretation.access`.
- Mimic the backend behavior regarding update/creation of comments: the user must have _write_ permissions on that interpretation; this will avoid some 403 we are now having. (Note that the backend is not right on this, though, to create/edit a comment, you shouldn't need to have _write_ access to the interpretation itself)