### PR TITLE
Add extra checks for favorite and interpretation access

### DIFF
--- a/src/api/Layout.js
+++ b/src/api/Layout.js
@@ -171,6 +171,14 @@ Layout = function(refs, c, applyConfig, forceApplyConfig) {
         return _access;
     };
 
+    t.canRead = function() {
+        return _access ? _access.read : false;
+    };
+
+    t.canUpdate = function() {
+        return _access ? _access.update : false;
+    };
+
     t.setAccess = function(a) {
         _access = a;
     };
@@ -550,6 +558,8 @@ Layout.prototype.toPostSuper = function() {
     delete this.getResponse;
     delete this.setResponse;
     delete this.getAccess;
+    delete this.canRead;
+    delete this.canUpdate;
     delete this.setAccess;
     delete this.getDataDimensionItems;
     delete this.setDataDimensionItems;

--- a/src/ui/EastRegion.js
+++ b/src/ui/EastRegion.js
@@ -178,7 +178,7 @@ EastRegion = function(c) {
                 }
 
                 // Change Link
-                if (layout && layout.getAccess().update) {
+                if (layout && layout.canUpdate && layout.canUpdate()) {
                     descriptionItems.push({
                         xtype: 'label',
                         html: getLink(editText, false, true),
@@ -241,7 +241,7 @@ EastRegion = function(c) {
             }
 
             // Favorite Details Panel content when favorite loaded
-            var userCanEditSharing = layout && layout.getAccess().update;
+            var userCanEditSharing = layout && layout.canUpdate && layout.canUpdate();
 
             detailsPanelItems = [{
                 xtype: 'panel',
@@ -397,7 +397,7 @@ EastRegion = function(c) {
                 bodyStyle: 'border-style:none',
                 layout: 'column',
                 itemId: 'commentPanel-' + (comment ? comment.id : "new"),
-                hidden: !visible || !interpretation.access.update,
+                hidden: !visible || !interpretation.access || !interpretation.access.update,
                 style: 'margin-top: 1px;',
                 cls: 'comment greyBackground',
                 items: [{
@@ -536,13 +536,13 @@ EastRegion = function(c) {
                         }, {
                             xtype: 'label',
                             style: 'color: #666',
-                            hidden: !interpretation.access.update,
+                            hidden: !interpretation.access || !interpretation.access.update,
                             text: DateManager.getTimeDifference(comment.lastUpdated) + ' ' + i18n.ago
                         }, {
                             xtype: 'label',
                             html: getLink(i18n.reply),
                             style: 'margin-right: 5px; margin-left: 5px',
-                            hidden: !interpretation.access.update,
+                            hidden: !interpretation.access || !interpretation.access.update,
                             listeners: {
                                 'render': (function(comment_) {
                                     return function(label) {
@@ -825,7 +825,7 @@ EastRegion = function(c) {
                     xtype: 'panel',
                     bodyStyle: 'border-style:none',
                     style: 'margin-bottom: 5px;',
-                    hidden: !interpretation.access.read,
+                    hidden: !interpretation.access || !interpretation.access.read,
 
                     items: [{
                         xtype: 'label',
@@ -838,12 +838,12 @@ EastRegion = function(c) {
                         }
                     }, {
                         xtype: 'label',
-                        hidden: !interpretation.access.update,
+                        hidden: !interpretation.access || !interpretation.access.update,
                         text: '·',
                         style: 'margin-right: 5px;'
                     }, {
                         xtype: 'label',
-                        hidden: !interpretation.access.update,
+                        hidden: !interpretation.access || !interpretation.access.update,
                         html: getLink(i18n.reply),
                         style: 'margin-right: 5px;',
                         listeners: {
@@ -988,7 +988,7 @@ EastRegion = function(c) {
             xtype: 'panel',
             bodyStyle: 'border-style:none',
             style: 'padding:6px; border-width:0 0 1px 0; border-style:solid;',
-            hidden: displayingInterpretation || (!layout || !layout.getAccess().read),
+            hidden: displayingInterpretation || (!layout || !layout.canRead || !layout.canRead()),
             itemId: 'shareInterpretation',
             items: [{
                 xtype: 'label',


### PR DESCRIPTION
[Internal PR for reviewing, open PR upstream]

Fixes error reports, on a new favorite, the `access` object or the favorite itself can be null/empty. Add defensive code. 