### PR TITLE
[OCG] [Feature] Add options translations and increase default page size for option sets event visualizer for DHIS 2.42

### DIFF
--- a/src/api/Request.js
+++ b/src/api/Request.js
@@ -7,6 +7,8 @@ import arrayClean from 'd2-utilizr/lib/arrayClean';
 import arrayContains from 'd2-utilizr/lib/arrayContains';
 import arrayFrom from 'd2-utilizr/lib/arrayFrom';
 
+import { unescape } from '../util/sanitize';
+
 export var Request;
 
 Request = function(refs, config) {
@@ -152,7 +154,7 @@ Request.prototype.url = function(extraParams) {
 
 Request.prototype.run = function(config) {
     var t = this,
-        url = encodeURI(this.url());
+        url = unescape(encodeURI(this.url()));
 
     config = isObject(config) ? config : {};
 

--- a/src/api/Request.js
+++ b/src/api/Request.js
@@ -147,14 +147,14 @@ Request.prototype.setComplete = function(fn) {
 Request.prototype.url = function(extraParams) {
     var params = arrayClean([].concat(this.params, arrayFrom(extraParams)));
 
-    return this.baseUrl + (params.length ? '?' + params.join('&') : '');
+    return unescape(this.baseUrl + (params.length ? '?' + params.join('&') : ''));
 };
 
 // dep 1
 
 Request.prototype.run = function(config) {
     var t = this,
-        url = unescape(encodeURI(this.url()));
+        url = this.url();
 
     config = isObject(config) ? config : {};
 

--- a/src/index.js
+++ b/src/index.js
@@ -66,6 +66,7 @@ import { categoryOptionGroupSetsInit } from './init/categoryOptionGroupSetsInit.
 import { SimpleRegression } from './util/SimpleRegression.js';
 import { Plugin } from './util/Plugin.js';
 import * as dom from './util/dom.js';
+import * as sanitize from './util/sanitize.js';
 
 import { extOverrides } from './override/extOverrides.js';
 import { extChartOverrides } from './override/extChartOverrides.js';
@@ -232,6 +233,7 @@ export const util = {
     SimpleRegression,
     Plugin,
     dom,
+    sanitize
 };
 
 export const override = {

--- a/src/util/sanitize.js
+++ b/src/util/sanitize.js
@@ -1,0 +1,26 @@
+/* Escape characters in the URL.
+ *
+ * Given the current implementation of the requests, where strings are aded unescaped to the URL,
+ * there is no good way to handle this. Special chars like '&' or '%' are being simply added, which
+ * will generate a wrong URL. Neither can we simply encodeURIComponent it as %CODE, as % will be
+ * escaped again by request.run (which calls encodeURI).
+ *
+ * Workaround:
+ *   - Escape literal '%' -> '!!!'
+ *   - encodeURIComponent (so we get '%NN' escapes)
+ *   - Custom escape '%NN' to '@@@NN'
+ *   - Unescape '!!!' to recover '%' literals
+ * */
+
+const percentLiteralEscaped = '!!!';
+const percentEscaped = '@@@';
+
+export function escape(s) {
+    return encodeURIComponent(s.replace(/%/g, percentLiteralEscaped))
+             .replace(/%/g, percentEscaped)
+             .replace(new RegExp(percentLiteralEscaped, "g"), percentEscaped + '26');
+}
+
+export function unescape(s) {
+    return s.replace(new RegExp(percentEscaped, "g"), '%');
+}

--- a/src/ux/GroupSetContainer.js
+++ b/src/ux/GroupSetContainer.js
@@ -50,7 +50,10 @@ GroupSetContainer = function(refs) {
             }
         },
         getOptionSetOptions: (optionSetId, filters, limit, callbackFn) => {
-            const params = [`filter=optionSet.id:eq:${optionSetId}`, 'fields=code,name'];
+            const params = [
+              `filter=optionSet.id:eq:${optionSetId}`,
+              'fields=code,displayName~rename(name)',
+            ];
 
             if (limit) {
                 params.push(`pageSize=${defaultPageSize}`);

--- a/src/ux/GroupSetContainer.js
+++ b/src/ux/GroupSetContainer.js
@@ -5,6 +5,8 @@ import isArray from 'd2-utilizr/lib/isArray';
 import isObject from 'd2-utilizr/lib/isObject';
 import isString from 'd2-utilizr/lib/isString';
 
+import { escape } from '../util/sanitize';
+
 import containerConfig from './containerConfig';
 
 export var GroupSetContainer;
@@ -12,7 +14,7 @@ export var GroupSetContainer;
 GroupSetContainer = function(refs) {
     var { api, appManager } = refs;
 
-    const defaultPageSize = 100;
+    const defaultPageSize = 500;
 
     Ext.define('Ext.ux.container.GroupSetContainer', {
         extend: 'Ext.container.Container',
@@ -245,7 +247,8 @@ GroupSetContainer = function(refs) {
                     var me = this,
                         records = [];
 
-                    const filter = `code:in:[${codeArray.join(',')}]`;
+                    const codes = codeArray.map(escape).join(',');
+                    const filter = `code:in:[${codes}]`;
 
                     container.getOptionSetOptions(
                         container.dataElement.optionSet.id,


### PR DESCRIPTION
### Refs

Tasks: 
- [[1499] Maintain Event Report and Event Visualizer in 2.42](https://app.clickup.com/t/869d0f0b5)

### Implementation

- Use `displayName~rename(name)` for options names to enable the use if the API translations.
- Merge of PR #32 to deploy our fixes in DHIS2.42 instances.

Used with event-charts-app

#869d0f0b5