### PR TITLE
[OCA][Fix] Pivot table exception on high dimensions count

### DIFF
--- a/src/manager/TableManager.js
+++ b/src/manager/TableManager.js
@@ -128,7 +128,7 @@ TableManager = function(c) {
 
         // get objects
         for (var i = 0; i < uuids.length; i++) {
-            objects.push(uuidObjectMap[uuids[i]]);
+            objects.push(uuidObjectMap.get(uuids[i]));
         }
 
         // clear layoutConfig dimension items
@@ -412,19 +412,15 @@ TableManager = function(c) {
         };
 
         if (table.colAxis && table.colAxis.uuidObjectMap) {
-            for (const key in table.colAxis.uuidObjectMap) {
-                if (table.colAxis.uuidObjectMap.hasOwnProperty(key)) {
-                    setMouseHandler(table.colAxis.uuidObjectMap[key]);
-                }
-            }
+            table.colAxis.uuidObjectMap.forEach((value) => {
+                setMouseHandler(value);
+            });
         }
 
         if (table.rowAxis && table.rowAxis.uuidObjectMap) {
-            for (const key in table.rowAxis.uuidObjectMap) {
-                if (table.rowAxis.uuidObjectMap.hasOwnProperty(key)) {
-                    setMouseHandler(table.rowAxis.uuidObjectMap[key]);
-                }
-            }
+            table.rowAxis.uuidObjectMap.forEach((value) => {
+                setMouseHandler(value);
+            });
         }
     }
 };

--- a/src/table/PivotTable.js
+++ b/src/table/PivotTable.js
@@ -677,10 +677,23 @@ PivotTable.prototype.getDivisorValue = function(id) {
  * @returns {object}
  */
 PivotTable.prototype.getUuidObjectMap = function() {
-    return objectApplyIf(
-        (this.colAxis ? this.colAxis.uuidObjectMap : {}),
-        (this.rowAxis ? this.rowAxis.uuidObjectMap : {})
-    );
+    const mergedMap = new Map();
+
+    if (this.colAxis && this.colAxis.uuidObjectMap) {
+        for (const [key, value] of this.colAxis.uuidObjectMap) {
+            mergedMap.set(key, value);
+        }
+    }
+
+    if (this.rowAxis && this.rowAxis.uuidObjectMap) {
+        for (const [key, value] of this.rowAxis.uuidObjectMap) {
+            if (!mergedMap.has(key)) {
+                mergedMap.set(key, value);
+            }
+        }
+    }
+
+    return mergedMap;
 };
 
 /**

--- a/src/table/PivotTableAxis.js
+++ b/src/table/PivotTableAxis.js
@@ -36,7 +36,7 @@ export const PivotTableAxis = function(refs, layout, response, type, options = {
     this.response = response;
 
     this.totalLookup = {};
-    this.uuidObjectMap = {};
+    this.uuidObjectMap = new Map();
     this.items = [];
     this.span = [];
     this.ids = [];
@@ -108,7 +108,7 @@ export const PivotTableAxis = function(refs, layout, response, type, options = {
                 isOrganisationUnit: response.hasIdByDimensionName(id, 'ou'),
             };
 
-            this.uuidObjectMap[dimensionObject.uuid] = dimensionObject;
+            this.uuidObjectMap.set(dimensionObject.uuid, dimensionObject);
 
             if (dimensionIndex !== 0) {
                 dimensionObject.parent = aaAllFloorObjects[dimensionIndex - 1][positionIndex];

--- a/src/table/PivotTableAxis.js
+++ b/src/table/PivotTableAxis.js
@@ -63,6 +63,26 @@ export const PivotTableAxis = function(refs, layout, response, type, options = {
 
     const dimensionNameIdsMap = layout.getDimensionNameIdsMap(response, layout.hideNaData ? dimensionIdsFilterFn : null);
 
+    // Remove dimension IDs that have no data in response.
+    this.items.forEach((dimension) => {
+        const dimName = dimension.dimension;
+        const header = response.getHeaderByName(dimName);
+        if (!header || !dimensionNameIdsMap[dimName]) return;
+
+        const activeIds = new Set();
+        response.rows.forEach((row) => {
+            let id = row.getAt(header.getIndex());
+            if (header.isPrefix) {
+                id = response.getPrefixedId(id, dimName);
+            };
+            activeIds.add(id);
+        });
+
+        if (activeIds.size > 0) {
+            dimensionNameIdsMap[dimName] = dimensionNameIdsMap[dimName].filter((id) => activeIds.has(id));
+        }
+    });
+
     const aaUniqueFloorIds = (() => {
         let dims;
 


### PR DESCRIPTION
### Refs
 
- [[7] Issue with DHIS2 Event Report App – XLS Download and Hep C Dataset](https://app.clickup.com/t/4528615/869deqqxr)

### Description

When trying to render a pivot table with a high amount of dimensions (DEs and their options, periods, etc) an exception can occur due to a large resulting object in PivotTableAxis.

The issue was addressed in two ways:
- Use a Map to store the data instead of plain properties, this allows the object to be larger.
- Filter out dimensions that have no data. That way the processing time and memory use is reduced if many of the dimensions combinations have no data.

Intended to be used with: [event-reports-app#7](https://github.com/EyeSeeTea/event-reports-app/pull/7)

#869deqqxr