### PR TITLE
[OCG] [Feature] Use analytics display property for pivot table data label

### DIFF
--- a/src/api/Request.js
+++ b/src/api/Request.js
@@ -7,6 +7,8 @@ import arrayClean from 'd2-utilizr/lib/arrayClean';
 import arrayContains from 'd2-utilizr/lib/arrayContains';
 import arrayFrom from 'd2-utilizr/lib/arrayFrom';
 
+import { unescape } from '../util/sanitize';
+
 export var Request;
 
 Request = function(refs, config) {
@@ -145,14 +147,14 @@ Request.prototype.setComplete = function(fn) {
 Request.prototype.url = function(extraParams) {
     var params = arrayClean([].concat(this.params, arrayFrom(extraParams)));
 
-    return this.baseUrl + (params.length ? '?' + params.join('&') : '');
+    return unescape(this.baseUrl + (params.length ? '?' + params.join('&') : ''));
 };
 
 // dep 1
 
 Request.prototype.run = function(config) {
     var t = this,
-        url = encodeURI(this.url());
+        url = this.url();
 
     config = isObject(config) ? config : {};
 

--- a/src/api/Response.js
+++ b/src/api/Response.js
@@ -380,6 +380,24 @@ Response.prototype.getNameById = function(id) {
     return (this.metaData.items[id] || {}).name || id;
 };
 
+Response.prototype.getDisplayNameById = function (id) {
+    if (!this.metaData.dimensions[id] || id === "pe" || id === "ou") {
+        return this.getNameById(id);
+    }
+
+    const item = this.metaData.items[id] || {};
+    const appManager = this.getRefs().appManager;
+    const displayProperty = appManager ? appManager.getAnalyticsDisplayProperty() : "NAME";
+
+    if (displayProperty === "SHORTNAME") {
+        const header = this.getHeaderByName(id);
+        const shortName = header.column || undefined;
+        return shortName || item.name || id;
+    }
+
+    return item.name || id;
+};
+
 Response.prototype.getHierarchyNameById = function(id, isHierarchy, isHtml) {
     var metaData = this.metaData,
         name = '';

--- a/src/api/Response.js
+++ b/src/api/Response.js
@@ -380,7 +380,7 @@ Response.prototype.getNameById = function(id) {
     return (this.metaData.items[id] || {}).name || id;
 };
 
-Response.prototype.getDisplayNameById = function (id) {
+Response.prototype.getAnalysisDisplayNameById = function (id) {
     if (!this.metaData.dimensions[id] || id === "pe" || id === "ou") {
         return this.getNameById(id);
     }

--- a/src/index.js
+++ b/src/index.js
@@ -66,6 +66,7 @@ import { categoryOptionGroupSetsInit } from './init/categoryOptionGroupSetsInit.
 import { SimpleRegression } from './util/SimpleRegression.js';
 import { Plugin } from './util/Plugin.js';
 import * as dom from './util/dom.js';
+import * as sanitize from "./util/sanitize.js";
 
 import { extOverrides } from './override/extOverrides.js';
 import { extChartOverrides } from './override/extChartOverrides.js';
@@ -232,6 +233,7 @@ export const util = {
     SimpleRegression,
     Plugin,
     dom,
+    sanitize,
 };
 
 export const override = {

--- a/src/table/PivotTable.js
+++ b/src/table/PivotTable.js
@@ -752,7 +752,7 @@ PivotTable.prototype.getColumnAxisLabel = function(rowIndex) {
 PivotTable.prototype.getRowAxisLabel = function(columnIndex) {
 
     if (this.rowAxis.dims) {
-        return this.response.getDisplayNameById(this.rowAxis.dimensionNames[columnIndex]);
+        return this.response.getAnalysisDisplayNameById(this.rowAxis.dimensionNames[columnIndex]);
     }
 
     return null;

--- a/src/table/PivotTable.js
+++ b/src/table/PivotTable.js
@@ -752,7 +752,7 @@ PivotTable.prototype.getColumnAxisLabel = function(rowIndex) {
 PivotTable.prototype.getRowAxisLabel = function(columnIndex) {
 
     if (this.rowAxis.dims) {
-        return this.response.getNameById(this.rowAxis.dimensionNames[columnIndex]);
+        return this.response.getDisplayNameById(this.rowAxis.dimensionNames[columnIndex]);
     }
 
     return null;

--- a/src/util/sanitize.js
+++ b/src/util/sanitize.js
@@ -3,3 +3,30 @@ import sanitizeHTML from 'sanitize-html'
 export default function(value) {
     return value ? sanitizeHTML(value) : ''
 }
+
+/* Escape characters in the URL.
+ *
+ * Given the current implementation of the requests, where strings are aded unescaped to the URL,
+ * there is no good way to handle this. Special chars like '&' or '%' are being simply added, which
+ * will generate a wrong URL. Neither can we simply encodeURIComponent it as %CODE, as % will be
+ * escaped again by request.run (which calls encodeURI).
+ *
+ * Workaround:
+ *   - Escape literal '%' -> '!!!'
+ *   - encodeURIComponent (so we get '%NN' escapes)
+ *   - Custom escape '%NN' to '@@@NN'
+ *   - Unescape '!!!' to recover '%' literals
+ * */
+
+const percentLiteralEscaped = '!!!';
+const percentEscaped = '@@@';
+
+export function escape(s) {
+    return encodeURIComponent(s.replace(/%/g, percentLiteralEscaped))
+             .replace(/%/g, percentEscaped)
+             .replace(new RegExp(percentLiteralEscaped, "g"), percentEscaped + '26');
+}
+
+export function unescape(s) {
+    return s.replace(new RegExp(percentEscaped, "g"), '%');
+}

--- a/src/ux/GroupSetContainer.js
+++ b/src/ux/GroupSetContainer.js
@@ -5,6 +5,8 @@ import isArray from 'd2-utilizr/lib/isArray';
 import isObject from 'd2-utilizr/lib/isObject';
 import isString from 'd2-utilizr/lib/isString';
 
+import { escape } from '../util/sanitize';
+
 import containerConfig from './containerConfig';
 
 export var GroupSetContainer;
@@ -12,7 +14,7 @@ export var GroupSetContainer;
 GroupSetContainer = function(refs) {
     var { api, appManager } = refs;
 
-    const defaultPageSize = 100;
+    const defaultPageSize = 500;
 
     Ext.define('Ext.ux.container.GroupSetContainer', {
         extend: 'Ext.container.Container',
@@ -51,7 +53,7 @@ GroupSetContainer = function(refs) {
             }
         },
         getOptionSetOptions: (optionSetId, filters, limit, callbackFn) => {
-            const params = [`filter=optionSet.id:eq:${optionSetId}`, 'fields=code,name'];
+            const params = [`filter=optionSet.id:eq:${optionSetId}`, "fields=code,displayName~rename(name)"];
 
             if (limit) {
                 params.push(`pageSize=${defaultPageSize}`);
@@ -248,7 +250,8 @@ GroupSetContainer = function(refs) {
                     var me = this,
                         records = [];
 
-                    const filter = `code:in:[${codeArray.join(',')}]`;
+                    const codes = codeArray.map(escape).join(',');
+                    const filter = `code:in:[${codes}]`;
 
                     container.getOptionSetOptions(
                         container.dataElement.optionSet.id,


### PR DESCRIPTION
### Refs

Tasks: 
- [[1401] Event Reports not showing translated data elements in french](https://app.clickup.com/t/869buzmaa)

### Implementation

Intended to use with: https://github.com/EyeSeeTea/event-reports-app/pull/5

- Added modified `Response.getNameById` named `Response.getDisplayNameById` to use display the shortName if its selected insted of name.
- Use `d2-analysis v33.3.2` to fix the display of line lists and other issues like blank DEs names when opening a saved report with  `v33.3.4` .
- Include previous fixes:
   - Use `displayName~rename(name)` for options names to enable the use if the API translations.
   - Increase GroupSetContainer defaultPageSize from 100 to 500.
   - Add URL sanitizing.

Used with event-reports-app

#869buzmaa